### PR TITLE
Potential fix for code scanning alert no. 2: Local information disclosure in a temporary directory

### DIFF
--- a/src/test/java/se/sundsvall/esigning/integration/document/model/DocumentMultipartFileTest.java
+++ b/src/test/java/se/sundsvall/esigning/integration/document/model/DocumentMultipartFileTest.java
@@ -6,6 +6,8 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 import generated.se.sundsvall.comfactfacade.Document;
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -85,7 +87,7 @@ class DocumentMultipartFileTest {
 			.content(content);
 		final var multipartFile = DocumentMultipartFile.create(document);
 
-		final var file = File.createTempFile("test_", null);
+		final var file = Files.createTempFile("test_", null).toFile();
 		multipartFile.transferTo(file);
 
 		assertThat(file).exists();


### PR DESCRIPTION
Potential fix for [https://github.com/Sundsvallskommun/pw-e-signing/security/code-scanning/2](https://github.com/Sundsvallskommun/pw-e-signing/security/code-scanning/2)

To fix the problem, replace the use of `File.createTempFile` with the more secure `Files.createTempFile` from `java.nio.file`, which creates files with permissions that restrict access to the owner (`-rw-------`). This change should be made on line 88 of `DocumentMultipartFileTest.java`. The returned object from `Files.createTempFile` is a `Path`, so you will need to convert it to a `File` using `toFile()`. You will also need to import `java.nio.file.Files` and `java.nio.file.Path` if they are not already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
